### PR TITLE
Add FastAPI web app for property chatbot

### DIFF
--- a/speech-to-speech/repeatable-patterns/property-listing-chatbot/README.md
+++ b/speech-to-speech/repeatable-patterns/property-listing-chatbot/README.md
@@ -45,6 +45,30 @@ The script will print the transcript and text answer. A PCM file named
 `response_audio.pcm` is written containing the synthesized speech from the
 assistant.
 
+### Run web server
+
+Expose the chatbot through a REST API with FastAPI.
+
+```bash
+uvicorn web_app:app --reload
+```
+
+Send a text question:
+
+```bash
+curl -X POST http://localhost:8000/chat \
+  -H "Content-Type: application/json" \
+  -d '{"text": "3 bedroom house in Seattle"}'
+```
+
+Send a voice question:
+
+```bash
+curl -X POST http://localhost:8000/voice -F "file=@question.wav"
+```
+
+The `/voice` endpoint returns a transcript, text answer, and base64-encoded PCM audio.
+
 ## Notes
 
 This example focuses on illustrating how components fit together. Production

--- a/speech-to-speech/repeatable-patterns/property-listing-chatbot/requirements.txt
+++ b/speech-to-speech/repeatable-patterns/property-listing-chatbot/requirements.txt
@@ -1,2 +1,3 @@
 boto3>=1.34.0
-
+fastapi
+uvicorn

--- a/speech-to-speech/repeatable-patterns/property-listing-chatbot/web_app.py
+++ b/speech-to-speech/repeatable-patterns/property-listing-chatbot/web_app.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import base64
+from pathlib import Path
+
+from fastapi import FastAPI, UploadFile, File, HTTPException
+from pydantic import BaseModel
+
+from property_chatbot import (
+    PropertyRetriever,
+    LLMClient,
+    SonicClient,
+    PropertyChatbot,
+)
+
+
+app = FastAPI()
+
+# Instantiate core components once at startup
+_data_path = Path(__file__).with_name("properties.json")
+_retriever = PropertyRetriever(_data_path)
+_llm = LLMClient()
+_sonic = SonicClient()
+_bot = PropertyChatbot(_retriever, _llm, _sonic)
+
+
+class ChatRequest(BaseModel):
+    text: str
+
+
+@app.post("/chat")
+async def chat(req: ChatRequest):
+    if not req.text:
+        raise HTTPException(status_code=400, detail="text is required")
+    answer = _bot.ask_text(req.text)
+    return {"answer": answer}
+
+
+@app.post("/voice")
+async def voice(file: UploadFile = File(...)):
+    audio_bytes = await file.read()
+    result = _bot.ask_audio(audio_bytes)
+    audio_b64 = base64.b64encode(result["audio"]).decode("utf-8")
+    return {
+        "transcript": result["transcript"],
+        "answer": result["answer"],
+        "audio": audio_b64,
+    }
+
+
+if __name__ == "__main__":
+    import uvicorn
+
+    uvicorn.run(app, host="0.0.0.0", port=8000)


### PR DESCRIPTION
## Summary
- add FastAPI `web_app.py` with `/chat` and `/voice` endpoints built on PropertyChatbot
- document running the new REST API server with example curl commands
- add FastAPI and Uvicorn dependencies

## Testing
- `python -m py_compile speech-to-speech/repeatable-patterns/property-listing-chatbot/web_app.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68923620ac108326b3436873eb68bcd0