### PR TITLE
Add web frontend for property listing chatbot

### DIFF
--- a/speech-to-speech/repeatable-patterns/property-listing-chatbot/README.md
+++ b/speech-to-speech/repeatable-patterns/property-listing-chatbot/README.md
@@ -45,6 +45,23 @@ The script will print the transcript and text answer. A PCM file named
 `response_audio.pcm` is written containing the synthesized speech from the
 assistant.
 
+
+### Web frontend
+
+A minimal browser-based interface lives under `static/`.
+
+1. Ensure a backend exposing `/chat` and `/voice` endpoints is running.
+2. Serve the static files, for example:
+
+```bash
+cd static
+python -m http.server 8000
+```
+
+3. Open `http://localhost:8000` in a browser. Use the textarea to send text,
+   press the microphone button to record a question, and the audio player will
+   play responses.
+
 ## Notes
 
 This example focuses on illustrating how components fit together. Production

--- a/speech-to-speech/repeatable-patterns/property-listing-chatbot/static/app.js
+++ b/speech-to-speech/repeatable-patterns/property-listing-chatbot/static/app.js
@@ -1,0 +1,55 @@
+const chatInput = document.getElementById('chatInput');
+const sendBtn = document.getElementById('send');
+const micBtn = document.getElementById('mic');
+const responseDiv = document.getElementById('response');
+const audioEl = document.getElementById('audio');
+
+sendBtn.onclick = async () => {
+  const text = chatInput.value.trim();
+  if (!text) return;
+  const res = await fetch('/chat', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ text })
+  });
+  const data = await res.json();
+  responseDiv.textContent = data.answer || '';
+  if (data.audio) {
+    audioEl.src = `data:audio/wav;base64,${data.audio}`;
+    audioEl.play();
+  }
+};
+
+let mediaRecorder;
+let audioChunks = [];
+
+micBtn.onclick = async () => {
+  if (!mediaRecorder || mediaRecorder.state === 'inactive') {
+    const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+    mediaRecorder = new MediaRecorder(stream);
+    mediaRecorder.ondataavailable = e => audioChunks.push(e.data);
+    mediaRecorder.onstop = async () => {
+      const blob = new Blob(audioChunks, { type: 'audio/webm' });
+      audioChunks = [];
+      const res = await fetch('/voice', {
+        method: 'POST',
+        headers: { 'Content-Type': 'audio/webm' },
+        body: blob
+      });
+      const data = await res.json();
+      let text = '';
+      if (data.transcript) text += `You: ${data.transcript}\n`;
+      if (data.answer) text += `Bot: ${data.answer}`;
+      responseDiv.textContent = text;
+      if (data.audio) {
+        audioEl.src = `data:audio/wav;base64,${data.audio}`;
+        audioEl.play();
+      }
+    };
+    mediaRecorder.start();
+    micBtn.textContent = 'Stop';
+  } else {
+    mediaRecorder.stop();
+    micBtn.textContent = '🎙️';
+  }
+};

--- a/speech-to-speech/repeatable-patterns/property-listing-chatbot/static/index.html
+++ b/speech-to-speech/repeatable-patterns/property-listing-chatbot/static/index.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>Property Listing Chatbot</title>
+  <style>
+    body { font-family: sans-serif; max-width: 600px; margin: auto; }
+    #chatInput { width: 100%; height: 80px; }
+    #mic { margin-left: 8px; }
+    #response { margin-top: 1em; white-space: pre-wrap; }
+  </style>
+</head>
+<body>
+  <h1>Property Listing Chatbot</h1>
+  <textarea id="chatInput" placeholder="Ask about properties"></textarea>
+  <button id="send">Send</button>
+  <button id="mic">🎙️</button>
+  <div id="response"></div>
+  <audio id="audio" controls></audio>
+
+  <script src="app.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add simple HTML/JS frontend for property listing chatbot with text input, mic recording, and audio playback
- document how to serve the static frontend

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6892362269448326a53bde746390032f