### PR TITLE
Improve credential error handling in property listing chatbot

### DIFF
--- a/speech-to-speech/repeatable-patterns/property-listing-chatbot/backend/README.md
+++ b/speech-to-speech/repeatable-patterns/property-listing-chatbot/backend/README.md
@@ -11,6 +11,12 @@ This directory hosts the FastAPI service and supporting modules for the property
    export AWS_SECRET_ACCESS_KEY=...
    export AWS_DEFAULT_REGION=us-east-1
    ```
+   On Windows PowerShell use:
+   ```powershell
+   setx AWS_ACCESS_KEY_ID "..."
+   setx AWS_SECRET_ACCESS_KEY "..."
+   setx AWS_DEFAULT_REGION "us-east-1"
+   ```
 
 ## Command line
 


### PR DESCRIPTION
## Summary
- handle missing AWS credentials in property chatbot clients with clearer error messages
- document Windows PowerShell commands for setting AWS credentials

## Testing
- `python -m py_compile speech-to-speech/repeatable-patterns/property-listing-chatbot/backend/property_chatbot.py`
- `python -m py_compile speech-to-speech/repeatable-patterns/property-listing-chatbot/backend/web_app.py`
- `python speech-to-speech/repeatable-patterns/property-listing-chatbot/backend/property_chatbot.py --text "3 bedroom house in Seattle"`


------
https://chatgpt.com/codex/tasks/task_e_68923b31defc83269957f6e9f2e6cbb3